### PR TITLE
BCC is treated as TO

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lodash": "^3.2.0",
     "node-tech-logger": "git://github.com/AirVantage/node-tech-logger.git#2.x",
     "nodemailer": "^1.3.0",
-    "nodemailer-sendgrid-transport": "^0.1.0",
+    "nodemailer-sendgrid-transport": "^0.2.0",
     "nodemailer-stub-transport": "^0.1.5"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Update dependency to nodemailer-sendgrid-transport in order to fix https://github.com/sendgrid/nodemailer-sendgrid-transport/issues/8
